### PR TITLE
build: make wolf usable as external dependency

### DIFF
--- a/wolf/CMakeLists.txt
+++ b/wolf/CMakeLists.txt
@@ -10,18 +10,18 @@ message("CXX Compiler ID is ${CMAKE_CXX_COMPILER_ID}")
 set(WEBRTC_SRC $ENV{WEBRTC_ROOT} CACHE STRING "path to the root folder of webrtc folder")
 
 # check the OS
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     if (WIN32)
         set(WIN64 TRUE)
     endif()
 endif()
 
-if(UNIX AND NOT APPLE)
+if (UNIX AND NOT APPLE)
    set(LINUX TRUE)
 endif()
 
 if (MSVC AND NOT WIN64)
-    message( FATAL_ERROR "Only Window 64 bit is supported" )
+    message(FATAL_ERROR "Only Window 64 bit is supported")
 endif()
 
 # set target os
@@ -29,22 +29,23 @@ if (WIN64)
     set(TARGET_OS "win")
     set(LIB_EXT "lib")
     set(SHARED_EXT "dll")
-elseif(APPLE)
+elseif (APPLE)
     set(TARGET_OS "mac")
     set(LIB_EXT "a")
     set(SHARED_EXT "dylib")
-elseif(LINUX)
+elseif (LINUX)
     set(TARGET_OS "linux")
     set(LIB_EXT "a")
     set(SHARED_EXT "so")
 else()
-    message( FATAL_ERROR "Unsuported OS, please open an issue at https://github.com/WolfEngine/WolfEngine" )
+    message(FATAL_ERROR "Unsuported OS, please open an issue at https://github.com/WolfEngine/WolfEngine")
 endif()
 
 # required packages
 find_package(Git REQUIRED)
+
 if (NOT EMSCRIPTEN)
-    find_package (Threads)
+    find_package(Threads)
 endif()
 
 # use folders
@@ -56,7 +57,7 @@ include(FetchContent)
 # set type of library
 set(LIBRARY_TYPE "STATIC" CACHE STRING "Library type")
 
-# CMAKE GUI Options
+# CMAKE Options
 # render modules
 option(WOLF_RENDER "Enable cross platform render engine based on Vulkan / OpenGL ES" OFF)
 
@@ -95,16 +96,16 @@ if (NOT MSVC)
     option(WOLF_ENABLE_ASAN "Enable ASAN" OFF)
 endif()
 
-if(ENABLE_LTO)
-  include(CheckIPOSupported)
-  check_ipo_supported(RESULT supported OUTPUT error)
-  if(supported)
-      message(STATUS "IPO / LTO enabled")
-      set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-      add_link_options(-fuse-ld=lld)
-  else()
-      message(STATUS "IPO / LTO not supported: <${error}>")
-  endif()
+if (ENABLE_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT supported OUTPUT error)
+    if (supported)
+        message(STATUS "IPO / LTO enabled")
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+        add_link_options(-fuse-ld=lld)
+    else()
+        message(STATUS "IPO / LTO not supported: <${error}>")
+    endif()
 endif()
 
 # media modules
@@ -132,38 +133,36 @@ set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 
-set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
-if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
-  set(CMAKE_BUILD_TYPE "Debug")
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Debug")
 endif()
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 
 # set C++23 as the primary standard
 set(CMAKE_CXX_STANDARD 23)
 
 # set C++ flags based on compiler
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-  # using Clang or AppleClang
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2b -fexceptions -fcoroutines-ts")
-  set(CMAKE_CXX_FLAGS_DEBUG "-g")
-  set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+    # using Clang or AppleClang
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2b -fexceptions -fcoroutines-ts")
+    set(CMAKE_CXX_FLAGS_DEBUG "-g")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  # using GCC
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2b -fexceptions -fcoroutines")
-  set(CMAKE_CXX_FLAGS_DEBUG "-g")
-  set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+    # using GCC
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2b -fexceptions -fcoroutines")
+    set(CMAKE_CXX_FLAGS_DEBUG "-g")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  # using Visual Studio C++
-  set(CMAKE_CXX_FLAGS "/EHsc /W3 /bigobj")
+    # using Visual Studio C++
+    set(CMAKE_CXX_FLAGS "/MDd /EHsc /W4 /bigobj")
 endif()
 
 if (ANDROID)
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 20)
 endif()
 
 set(GETOPT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/system)
 
-#define includes, libs and srcs
+# define includes, libs and srcs
 set(INCLUDES ${CMAKE_CURRENT_SOURCE_DIR})
 set(LIBS)
 set(SRCS)
@@ -212,10 +211,8 @@ if (MSVC)
         -DWIN32
     )
 elseif (EMSCRIPTEN)
-    add_definitions(
-        -DEMSCRIPTEN
-    )
-elseif(APPLE)
+    add_definitions(-DEMSCRIPTEN)
+elseif (APPLE)
     add_definitions(-DNEED_XLOCALE_H=1)
 endif()
 
@@ -224,15 +221,6 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 else()
     add_definitions(-DNDEBUG)
 endif()
-
-# setup Wolf definitions
-get_cmake_property(_vars VARIABLES)
-foreach (_var ${_vars})
-    string(FIND ${_var} "WOLF_" out)
-    if(("${out}" EQUAL 0) AND ("(${${_var}}" MATCHES ON))
-        add_definitions("-D${_var}")
-    endif()
-endforeach()
 
 # include sources
 file(GLOB_RECURSE WOLF_SRCS
@@ -244,9 +232,6 @@ file(GLOB_RECURSE WOLF_SRCS
 file(GLOB_RECURSE WOLF_CMAKES
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/*"
 )
-
-# includes
-include_directories(${INCLUDES})
 
 # add source codes
 add_library(${PROJECT_NAME} ${LIBRARY_TYPE} 
@@ -267,8 +252,21 @@ endif()
 #    endif()
 #endif()
 
+# setup Wolf definitions
+get_cmake_property(_vars VARIABLES)
+foreach (_var ${_vars})
+    string(FIND ${_var} "WOLF_" out)
+    if(("${out}" EQUAL 0) AND ("(${${_var}}" MATCHES ON))
+        target_compile_definitions(${PROJECT_NAME} PUBLIC "-D${_var}")
+    endif()
+endforeach()
+
+# includes
+target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 # link libraries
-target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${LIBS})
 
 # create source group
 source_group("wolf" FILES ${WOLF_SRCS})

--- a/wolf/cmake/media.cmake
+++ b/wolf/cmake/media.cmake
@@ -4,7 +4,6 @@ if (WOLF_MEDIA_FFMPEG)
     "${CMAKE_CURRENT_SOURCE_DIR}/media/ffmpeg/*"
   )
   list(APPEND SRCS ${WOLF_MEDIA_FFMPEG_SRC})
-  list(APPEND INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ffmpeg/include)
 
   list(APPEND FFMPEG_LIBS 
     avcodec 
@@ -16,9 +15,16 @@ if (WOLF_MEDIA_FFMPEG)
     swscale
     )
 
+  add_library(ffmpeg INTERFACE)
+  target_include_directories(ffmpeg INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/third_party/ffmpeg/include")
+  target_link_directories(ffmpeg INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/third_party/ffmpeg/bin")
+
   foreach (lib_name ${FFMPEG_LIBS})
-    list(APPEND LIBS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ffmpeg/lib/${TARGET_OS}/${lib_name}.${LIB_EXT})
+    set(lib_file "${CMAKE_CURRENT_SOURCE_DIR}/third_party/ffmpeg/lib/${TARGET_OS}/${lib_name}.${LIB_EXT}")
+    target_link_libraries(ffmpeg INTERFACE ${lib_file})
   endforeach()
+
+  list(APPEND LIBS ffmpeg)
 endif()
 
 # link openAL
@@ -43,8 +49,7 @@ if (WOLF_MEDIA_OPENAL)
   )
 
   list(APPEND SRCS ${WOLF_MEDIA_OPENAL_SRC})
-  list(APPEND INCLUDES ${openal_SOURCE_DIR}/include)
-  list(APPEND LIBS ${openal_BINARY_DIR}/${CMAKE_BUILD_TYPE}/OpenAL32.${LIB_EXT})    
+  list(APPEND LIBS OpenAL::OpenAL)
 
   set_target_properties(
     build_version
@@ -52,8 +57,7 @@ if (WOLF_MEDIA_OPENAL)
     ex-common
     OpenAL
     openal-info
-    PROPERTIES FOLDER "openAL") 
-
+    PROPERTIES FOLDER "openAL")
 endif()
 
 if (WOLF_MEDIA_STB)

--- a/wolf/cmake/stream.cmake
+++ b/wolf/cmake/stream.cmake
@@ -113,25 +113,34 @@ if (WOLF_STREAM_RIST)
     
     set(FETCHCONTENT_QUIET OFF)
     FetchContent_MakeAvailable(${RIST_TARGET})
+
+    # this file should be available after building rist
+    set(RIST_LIBRARY_BINARY_FILE ${rist_BINARY_DIR}/librist.a)
       
     if (ANDROID)
-      add_custom_command(OUTPUT rist_command.out COMMAND
-      /bin/bash "${CMAKE_CURRENT_SOURCE_DIR}/third_party/shells/librist/librist-android.sh" --build_dir=${rist_BINARY_DIR}
-       WORKING_DIRECTORY ${rist_SOURCE_DIR})
-      add_custom_target(rist ALL DEPENDS rist_command.out)
-      
-      list(APPEND LIBS
-        ${rist_BINARY_DIR}/librist.a)
-    else ()
-      STRING(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
-      
-      add_custom_command(OUTPUT rist_command.out COMMAND cmd /c "meson setup ${rist_BINARY_DIR} --backend vs2022 --default-library static --buildtype ${CMAKE_BUILD_TYPE_LOWER} & meson compile -C ${rist_BINARY_DIR}" WORKING_DIRECTORY ${rist_SOURCE_DIR})
-      add_custom_target(rist ALL DEPENDS rist_command.out)
+        add_custom_command(OUTPUT ${RIST_LIBRARY_BINARY_FILE}
+            COMMAND /bin/bash "${CMAKE_CURRENT_SOURCE_DIR}/third_party/shells/librist/librist-android.sh" --build_dir=${rist_BINARY_DIR}
+            WORKING_DIRECTORY ${rist_SOURCE_DIR})
+        add_custom_target(rist ALL DEPENDS ${RIST_LIBRARY_BINARY_FILE})
 
-      list(APPEND LIBS
-        ws2_32
-        ${rist_BINARY_DIR}/librist.a)
-        
+        add_library(rist INTERFACE)
+        add_dependencies(rist rist-build)
+        target_link_libraries(rist INTERFACE ${RIST_LIBRARY_BINARY_FILE})
+
+        list(APPEND LIBS rist)
+    else () # windows
+        STRING(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
+
+        add_custom_command(OUTPUT ${RIST_LIBRARY_BINARY_FILE}
+            COMMAND cmd /c "meson setup ${rist_BINARY_DIR} --backend vs2022 --default-library static --buildtype ${BUILD_TYPE_LOWER} & meson compile -C ${rist_BINARY_DIR}"
+            WORKING_DIRECTORY ${rist_SOURCE_DIR})
+        add_custom_target(rist-build ALL DEPENDS ${RIST_LIBRARY_BINARY_FILE})
+
+        add_library(rist INTERFACE)
+        add_dependencies(rist rist-build)
+        target_link_libraries(rist INTERFACE ${RIST_LIBRARY_BINARY_FILE})
+
+        list(APPEND LIBS ws2_32 rist)
     endif()
     
     list(APPEND INCLUDES

--- a/wolf/media/ffmpeg/w_ffmpeg.cpp
+++ b/wolf/media/ffmpeg/w_ffmpeg.cpp
@@ -284,12 +284,12 @@ boost::leaf::result<w_decoder> w_ffmpeg::create_decoder(
   _decoder.ctx.codec = avcodec_find_decoder(p_id);
   if (_decoder.ctx.codec == nullptr) {
     return W_FAILURE(std::errc::invalid_argument,
-                     "could not find decoder codec id: " + p_id);
+                     "could not find decoder codec id: " + std::to_string(p_id));
   }
   _decoder.ctx.parser = av_parser_init(_decoder.ctx.codec->id);
   if (_decoder.ctx.parser == nullptr) {
     return W_FAILURE(std::errc::invalid_argument,
-                     "could not initialize parser for codec id: " + p_id);
+                     "could not initialize parser for codec id: " + std::to_string(p_id));
   }
 
   BOOST_LEAF_CHECK(s_create(_decoder.ctx, p_config, p_codec_opts, p_opts));
@@ -392,7 +392,7 @@ boost::leaf::result<int> w_ffmpeg::open_stream_receiver(
 
   std::vector<AVStream *> _streams;
   _streams.reserve(_fmt_ctx->nb_streams);
-  for (auto i = 0; i < _fmt_ctx->nb_streams; ++i) {
+  for (auto i = 0u; i < _fmt_ctx->nb_streams; ++i) {
     _streams.push_back(_fmt_ctx->streams[i]);
   }
 

--- a/wolf/media/test/openal.hpp
+++ b/wolf/media/test/openal.hpp
@@ -3,7 +3,7 @@
     https://github.com/WolfEngine/WolfEngine
 */
 
-#if defined(WOLF_TEST) && defined(WOLF_MEDIA_OPENAL) && defined(WOLF_MEDIA_FFMPEG)
+#if defined(WOLF_TEST) && defined(WOLF_MEDIA_OPENAL)
 
 #pragma once
 
@@ -13,8 +13,10 @@
 #include <media/w_openal.hpp>
 
 BOOST_AUTO_TEST_CASE(openal_play_wav) {
+  using wolf::media::w_openal;
+  using wolf::media::w_openal_config;
+
   const wolf::system::w_leak_detector _detector = {};
-  using w_openal = wolf::media::w_openal;
 
   auto _current_dir =
       std::filesystem::current_path().append("../../content/audio/sine.wav");
@@ -26,6 +28,15 @@ BOOST_AUTO_TEST_CASE(openal_play_wav) {
   // let wolf_dir = current_dir.join("wolf");
   // let file_path = if wolf_dir.exists() { wolf_dir.join(file_name) }
   // else {current_dir.join(file_name)};
+
+  // make sure constructor works. later update with wav header.
+  [[maybe_unused]] auto openal = w_openal{
+    w_openal_config{
+      .format = AL_FORMAT_STEREO16,
+      .sample_rate = 48000,
+      .channels = 1
+    }
+  };
 }
 
 #endif

--- a/wolf/media/w_openal.hpp
+++ b/wolf/media/w_openal.hpp
@@ -161,7 +161,7 @@ public:
       alSourcePlay(this->_source);
 
       auto _error = get_last_error();
-      if (_error) {
+      if (!_error.empty()) {
         return W_FAILURE(std::errc::operation_canceled,
                      "error while updating openal because: " + _error);
       }
@@ -232,9 +232,7 @@ public:
   size_t _size_of_chunk = 0;
   LPALBUFFERCALLBACKSOFT _callback_ptr = nullptr;
 };
+
 } // namespace wolf::media
 
 #endif
-
-
-


### PR DESCRIPTION
# Pull Request Checklist

Please check if your pull request fulfills the following requirements:

<!-- Please check the one that applies to this pull request using "x". -->
  * [x] The commit message follows our guidelines
  * [ ] Tests for the changes have been added / updated (for feat / fix / refactor)
  * [ ] Docs for the changes have been added / updated (for feat / fix / refactor)

## Pull Request Type

What kind of change does this pull request introduce?

<!-- Please check the one that applies to this pull request using "x". -->
  * [x] Build: Changes that affect the build system or external dependencies
  * [ ] CD: Changes to our CD configuration files and scripts
  * [ ] CI: Changes to our CI configuration files and scripts
  * [ ] Docs: Documentation only changes
  * [ ] Feat: A new feature
  * [ ] Fix: A bug fix
  * [ ] Perf: A code change that improves performance
  * [ ] Refactor: A code change that neither fixes a bug nor adds a feature
  * [ ] Test: Adding missing tests or correcting existing tests

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
Issue #419 

## What is the new behavior?

This PR only concerns proper

Changes:
 - uses `target_*` functions instead of `include_directories` and `add_definition`, using `PUBLIC`, thus transferable to targets linking to wolf.
 - target links are now `PUBLIC` too, allowing static linking, and solving other linkage problems.
 - `CMAKE_BUILD_TYPE` is no long globally manipulated, and is updated (to `Debug`) only when it is not defined or is empty.
 - when msvc, `/MDd` compiler flag is added due links and usage of `crt`-related symbols.
 - when android, standard is explicitly set to `20` instead of `17`. requiring latest NDK (25 or >=23).

 - for OpenAL, now `OpenAL::OpenAL` target itself (shared library target provided by its repo) is used instead of directly linking to its static library file after build. the file would be at different paths depending on the generator used (MSBuild or Ninja or ...). aside the path problem, it wouldn't work for Android builds.
 - when FFmpeg enabled, tests were looking for dll files at runtime execution and raised error by Windows OS that they were not found, despite linking statically to prebuilt files. due this `wolf/third_party/ffmpeg/bin` is added to link directory path.
 - when RIST enabled, only tested with ninja build generator, there was a link configuration error that the file at specified path doesn't exist. this was due that the build dependency graph was not properly configured. it was fixed by making sure custom target building the library file would be executed before trying to link to this file.
 - used `w_openal` in its test case to ensure there will be a link and thus a link error when there is a problem with openal build configuration.


## Does this Pull Request introduce a breaking change?

<!-- Please check the one that applies to this pull request using "x". -->
  * [ ] Yes
  * [x] No

<!-- If this pull request contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Closes #419 